### PR TITLE
update company and jobs controllers to destroy when necessary

### DIFF
--- a/app/controllers/companies_controller.rb
+++ b/app/controllers/companies_controller.rb
@@ -37,6 +37,9 @@ class CompaniesController < ApplicationController
   end
 
   def destroy
+    @company.jobs.each do |job|
+      job.destroy
+    end
     @company.destroy
 
     flash[:success] = "#{@company.name} was successfully deleted!"

--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -44,6 +44,8 @@ class JobsController < ApplicationController
   end
 
   def destroy
+    @job.company.destroy if @job.company.jobs.length == 1
+    
     @job.destroy
 
     flash[:success] = "#{@job.title} was successfully deleted!"

--- a/spec/features/companies/user_deletes_a_company_spec.rb
+++ b/spec/features/companies/user_deletes_a_company_spec.rb
@@ -3,6 +3,9 @@ require 'rails_helper'
 describe "User deletes existing company" do
   scenario "a user can delete a company" do
     company = Company.create(name: "ESPN")
+    category = Category.create(title: 'wowowow')
+    job_1 = company.jobs.create!(title: "Developer", level_of_interest: 70, city: "Denver", category_id: category.id)
+    job_2 = company.jobs.create!(title: "super cool job", level_of_interest: 32, city: "Charlottesville", category_id: category.id)
     visit companies_path
 
     within(".company_#{company.id}") do
@@ -10,5 +13,6 @@ describe "User deletes existing company" do
     end
 
     expect(page).to have_content("ESPN was successfully deleted!")
+    expect(Job.all.count).to eq(0)
   end
 end

--- a/spec/features/jobs/user_deletes_a_job_spec.rb
+++ b/spec/features/jobs/user_deletes_a_job_spec.rb
@@ -12,6 +12,7 @@ describe "User deletes existing job" do
 
     expect(page).to have_content("CoolJob was successfully deleted!")
     expect(current_path).to eq(companies_path)
+    expect(Company.all.count).to eq(0)
   end
   scenario 'a user can delete from jobs page' do
     company = Company.create!(name: "company")
@@ -27,6 +28,7 @@ describe "User deletes existing job" do
 
     expect(page).to have_content("#{job_1.title} was successfully deleted!")
     expect(current_path).to eq(companies_path)
+    expect(Company.all.count).to eq(1)
   end
   scenario 'a user can delete from job show page' do
     company = Company.create!(name: "company")


### PR DESCRIPTION
built in logic to explicitly destroy companies when all their jobs were deleted and to delete a job when its parent company was deleted. also added to tests for this because TDD :) 